### PR TITLE
fix: support mysql8 syntax

### DIFF
--- a/tutorrichie/templates/richie/hooks/mysql/init
+++ b/tutorrichie/templates/richie/hooks/mysql/init
@@ -1,2 +1,4 @@
 mysql -u {{ MYSQL_ROOT_USERNAME }} --password="{{ MYSQL_ROOT_PASSWORD }}" --host "{{ MYSQL_HOST }}" --port {{ MYSQL_PORT }} -e 'CREATE DATABASE IF NOT EXISTS {{ RICHIE_MYSQL_DATABASE }};'
-mysql -u {{ MYSQL_ROOT_USERNAME }} --password="{{ MYSQL_ROOT_PASSWORD }}" --host "{{ MYSQL_HOST }}" --port {{ MYSQL_PORT }} -e 'GRANT ALL ON {{ RICHIE_MYSQL_DATABASE }}.* TO "{{ RICHIE_MYSQL_USERNAME }}"@"%" IDENTIFIED BY "{{ RICHIE_MYSQL_PASSWORD }}";'
+mysql -u {{ MYSQL_ROOT_USERNAME }} --password="{{ MYSQL_ROOT_PASSWORD }}" --host "{{ MYSQL_HOST }}" --port {{ MYSQL_PORT }} -e "CREATE USER IF NOT EXISTS '{{ RICHIE_MYSQL_USERNAME }}';"
+mysql -u {{ MYSQL_ROOT_USERNAME }} --password="{{ MYSQL_ROOT_PASSWORD }}" --host "{{ MYSQL_HOST }}" --port {{ MYSQL_PORT }} -e "ALTER USER '{{ RICHIE_MYSQL_USERNAME }}'@'%' IDENTIFIED BY '{{ RICHIE_MYSQL_PASSWORD }}';"
+mysql -u {{ MYSQL_ROOT_USERNAME }} --password="{{ MYSQL_ROOT_PASSWORD }}" --host "{{ MYSQL_HOST }}" --port {{ MYSQL_PORT }} -e "GRANT ALL ON {{ RICHIE_MYSQL_DATABASE }}.* TO '{{ RICHIE_MYSQL_USERNAME }}'@'%';"


### PR DESCRIPTION
In MySQL, if the `sql_require_primary_key` is turned on, no table can
exist without a primary key. Since the migration 0005 drops the primary
key field before model deletion, the table misses the primary key, hence
the migration will fail.

To prevent migration failure, we swap the primary key before dropping
the `revisionpluginrevision_ptr` field which is the actual primary key.
In case the migration need to be reverted, the opposite will happen and
we set the `revisionpluginrevision_ptr` as the primary key.

When selecting the new primary key, it doesn't really matter what we
set, since at the end of the migration we drop the whole table.

Signed-off-by: Gabor Boros <gabor.brs@gmail.com>