### PR TITLE
Add support for richie site factory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,8 @@ Every user-facing change should have an entry in this changelog. Please respect 
 
 ## [Unrealeased]
 
-- [Feature] Upgrade richie to v2.15.1
+- [Feature] Upgrade richie to v2.15.1 (by @BbrSofiane)
+- [Feature] Support deployment of richie site factory (by @BbrSofiane)
 
 Upgrade node to 16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,27 @@
+# Changelog
+
+<!--
+Every user-facing change should have an entry in this changelog. Please respect the following instructions:
+- Add your changes right below the "Unreleased" section title. If there are other unreleased changes,
+  add your own on top of them, as the first line in that section.
+- Indicate breaking changes by prepending an explosion 💥 character.
+- You may optionally append "(by <author>)" at the end of the line, where "<author>" is either one (just one)
+  of your GitHub username, real name or affiliated organization. These affiliations will be displayed in
+  he release notes for every release.
+- If you need to create a new release, create a separate commit just for that. It is important to respect these
+  instructions, because git commits are used to generate release notes:
+    - Add a "## vX.Y.Z (year-month-day)" line just below "## Unreleased", such that the new changes are now listed as part of release.
+    - The title of the commit should be the same as the section title: "vX.Y.Z (year-month-day)".
+    - The commit message should be copy-pasted from the release section.
+    - Have a look at other release commits for reference.
+-->
+
+## [Unrealeased]
+
+- [Feature] Upgrade richie to v2.15.1
+
+Upgrade node to 16
+
+## v14.0.0 (2022-06-09)
+
+- 💥[Feature] Upgrade to Nutmeg (by @regisb)

--- a/README.rst
+++ b/README.rst
@@ -45,7 +45,7 @@ Configuration
 
 This Tutor plugin comes with a few configuration settings:
 
-- ``RICHIE_RELEASE_VERSION`` (default: ``"v2.8.2"``)
+- ``RICHIE_RELEASE_VERSION`` (default: ``"v2.16.0"``)
 - ``RICHIE_HOST`` (default: ``"courses.{{ LMS_HOST }}"``)
 - ``RICHIE_MYSQL_DATABASE`` (default: ``"richie"``)
 - ``RICHIE_MYSQL_USERNAME`` (default: ``"richie"``)

--- a/tutorrichie/patches/local-docker-compose-dev-services
+++ b/tutorrichie/patches/local-docker-compose-dev-services
@@ -1,6 +1,13 @@
 richie:
+{% if RICHIE_FACTORY_REPOSITORY %}
+  command: ./manage.py runserver 0.0.0.0:8003
+{% else %}
   command: ./sandbox/manage.py runserver 0.0.0.0:8003
+{% endif %}
   env_file:
     - ../plugins/richie/apps/env.d/development
   ports:
-      - "8003:8003"
+    - "8003:8003"
+
+
+

--- a/tutorrichie/patches/local-docker-compose-jobs-services
+++ b/tutorrichie/patches/local-docker-compose-jobs-services
@@ -1,3 +1,15 @@
+{% if RICHIE_FACTORY_REPOSITORY %}
+richie-job:
+    image: {{ RICHIE_FACTORY_DOCKER_IMAGE }}
+    depends_on: {{ [("elasticsearch", RUN_ELASTICSEARCH), ("mysql", RUN_MYSQL)]|list_if }}
+    # Run as root to fix media permissions
+    user: root
+    env_file:
+      - ../plugins/richie/apps/env.d/production
+    volumes:
+      - ../plugins/richie/apps/settings/tutor.py:/app/richie/sites/{{ RICHIE_FACTORY_SITE }}/src/backend/{{ RICHIE_FACTORY_SITE }}/tutor.py:ro
+      - ../../data/richie/media:/data/media
+{% else %}
 richie-job:
     image: {{ RICHIE_DOCKER_IMAGE }}
     depends_on: {{ [("elasticsearch", RUN_ELASTICSEARCH), ("mysql", RUN_MYSQL)]|list_if }}
@@ -8,6 +20,7 @@ richie-job:
     volumes:
       - ../plugins/richie/apps/settings/tutor.py:/app/richie/sandbox/tutor.py:ro
       - ../../data/richie/media:/data/media
+{% endif %}
 richie-openedx-job:
     image: {{ DOCKER_IMAGE_OPENEDX }}
     environment:

--- a/tutorrichie/patches/local-docker-compose-services
+++ b/tutorrichie/patches/local-docker-compose-services
@@ -1,3 +1,19 @@
+{% if RICHIE_FACTORY_REPOSITORY %}
+richie:
+  image: {{ RICHIE_FACTORY_DOCKER_IMAGE }}
+  restart: unless-stopped
+  user: "1000:1000"
+  env_file:
+    - ../plugins/richie/apps/env.d/production
+  volumes:
+    - ../plugins/richie/apps/settings/tutor.py:/app/richie/sites/{{ RICHIE_FACTORY_SITE }}/src/backend/{{ RICHIE_FACTORY_SITE }}/tutor.py:ro
+    - ../../data/richie/media:/data/media
+  depends_on:
+    - richie-permissions
+    {% if RUN_ELASTICSEARCH %}- elasticsearch{% endif %}
+    {% if RUN_LMS %}- lms{% endif %}
+    {% if RUN_MYSQL %}- mysql{% endif %}
+{% else %}
 richie:
   image: {{ RICHIE_DOCKER_IMAGE }}
   restart: unless-stopped
@@ -12,6 +28,8 @@ richie:
     {% if RUN_ELASTICSEARCH %}- elasticsearch{% endif %}
     {% if RUN_LMS %}- lms{% endif %}
     {% if RUN_MYSQL %}- mysql{% endif %}
+{% endif %}
+
 
 richie-permissions:
   image: {{ DOCKER_IMAGE_PERMISSIONS }}

--- a/tutorrichie/patches/openedx-common-settings
+++ b/tutorrichie/patches/openedx-common-settings
@@ -1,2 +1,6 @@
 # Richie settings (common)
 FEATURES["ENABLE_MKTG_SITE"] = True
+
+CSRF_COOKIE_NAME = "edx_csrf_token"
+CSRF_COOKIE_DOMAIN = ".{{ LMS_HOST }}"
+SESSION_COOKIE_NAME = "edx_session"

--- a/tutorrichie/patches/openedx-lms-development-settings
+++ b/tutorrichie/patches/openedx-lms-development-settings
@@ -1,2 +1,3 @@
 # Richie (lms development)
 CORS_ORIGIN_WHITELIST.append("http://{{ RICHIE_HOST }}:8003")
+CSRF_TRUSTED_ORIGINS.append("{{ RICHIE_HOST }}:8003")

--- a/tutorrichie/patches/openedx-lms-production-settings
+++ b/tutorrichie/patches/openedx-lms-production-settings
@@ -5,3 +5,9 @@ MKTG_URLS = {
   "ROOT": RICHIE_ROOT_URL
 }
 CORS_ORIGIN_WHITELIST.append("{% if ENABLE_HTTPS %}https{% else %}http{% endif %}://{{ RICHIE_HOST }}")
+CSRF_TRUSTED_ORIGINS.append("{{ RICHIE_HOST }}")
+RICHIE_COURSE_HOOK = {
+  "secret": "{{ RICHIE_HOOK_SECRET }}",
+  "url": "http://richie:8000/api/v1.0/course-runs-sync/",
+  "timeout": 3,
+}

--- a/tutorrichie/plugin.py
+++ b/tutorrichie/plugin.py
@@ -15,16 +15,21 @@ config = {
     "defaults": {
         "VERSION": __version__,
         "DOCKER_IMAGE": "{{ DOCKER_REGISTRY }}overhangio/openedx-richie:{{ RICHIE_VERSION }}",
-        "RELEASE_VERSION": "v2.15.1",
+        "FACTORY_DOCKER_IMAGE": "{{ DOCKER_REGISTRY }}overhangio/openedx-richie-factory:{{ RICHIE_VERSION }}",
+        "RELEASE_VERSION": "v2.16.0",
         "HOST": "courses.{{ LMS_HOST }}",
         "MYSQL_DATABASE": "richie",
         "MYSQL_USERNAME": "richie",
         "ELASTICSEARCH_INDICES_PREFIX": "richie",
+        "FACTORY_REPOSITORY": "",
     },
 }
 
 hooks = {
-    "build-image": {"richie": "{{ RICHIE_DOCKER_IMAGE }}"},
+    "build-image": {
+        "richie": "{{ RICHIE_DOCKER_IMAGE }}",
+        "richie-factory": "{{ RICHIE_FACTORY_DOCKER_IMAGE }}",
+    },
     "remote-image": {"richie": "{{ RICHIE_DOCKER_IMAGE }}"},
     "init": ["mysql", "richie", "richie-openedx"],
 }

--- a/tutorrichie/plugin.py
+++ b/tutorrichie/plugin.py
@@ -15,7 +15,7 @@ config = {
     "defaults": {
         "VERSION": __version__,
         "DOCKER_IMAGE": "{{ DOCKER_REGISTRY }}overhangio/openedx-richie:{{ RICHIE_VERSION }}",
-        "RELEASE_VERSION": "v2.9.1",
+        "RELEASE_VERSION": "v2.15.1",
         "HOST": "courses.{{ LMS_HOST }}",
         "MYSQL_DATABASE": "richie",
         "MYSQL_USERNAME": "richie",

--- a/tutorrichie/templates/richie/apps/env.d/production
+++ b/tutorrichie/templates/richie/apps/env.d/production
@@ -1,4 +1,13 @@
+{% if RICHIE_FACTORY_REPOSITORY %}
+# Caches settings - makes debugging faster
+# TODO Configure to use the redis service
+CACHE_DEFAULT_BACKEND=django.core.cache.backends.locmem.LocMemCache
+CACHE_DEFAULT_LOCATION=""
+CACHE_DEFAULT_OPTIONS={}
+DJANGO_SETTINGS_MODULE={{ RICHIE_FACTORY_SITE }}.tutor
+{% else %}
 DJANGO_SETTINGS_MODULE=tutor
+{% endif %}
 DJANGO_CONFIGURATION=TutorProduction
 DJANGO_SECRET_KEY={{ RICHIE_SECRET_KEY}}
 DJANGO_ALLOWED_HOSTS=richie,{{ RICHIE_HOST }}

--- a/tutorrichie/templates/richie/apps/settings/tutor.py
+++ b/tutorrichie/templates/richie/apps/settings/tutor.py
@@ -2,7 +2,11 @@ from django.conf import global_settings, settings
 from django.utils.translation import gettext_lazy as _
 
 from configurations import values
+{% if RICHIE_FACTORY_REPOSITORY %}
+from {{ RICHIE_FACTORY_SITE }}.settings import Development, Production
+{% else %}
 from settings import Development, Production
+{% endif %}
 
 supported_languages = [("en", _("English")),]
 extra_language_code = "{{ LANGUAGE_CODE }}"
@@ -55,6 +59,8 @@ class TutorSettingsMixin:
     }
     PARLER_LANGUAGES = CMS_LANGUAGES
 
+    SESSION_ENGINE = "django.contrib.sessions.backends.db"
+
     {{ patch("richie-settings-common")|indent(4) }}
 
 class TutorProduction(TutorSettingsMixin, Production):
@@ -68,6 +74,7 @@ class TutorProduction(TutorSettingsMixin, Production):
     SESSION_COOKIE_SECURE = False
     {% endif %}
 
+    TEXT_CKEDITOR_BASE_PATH = f"//{{RICHIE_HOST}}/static/djangocms_text_ckeditor/ckeditor/"
     {{ patch("richie-settings-production")|indent(4) }}
 
 

--- a/tutorrichie/templates/richie/build/richie-factory/Dockerfile
+++ b/tutorrichie/templates/richie/build/richie-factory/Dockerfile
@@ -1,3 +1,5 @@
+ARG SITE={{ RICHIE_FACTORY_SITE }}
+
 #--------- Base image with cloned repo
 FROM python:3.7-bullseye as base
 
@@ -6,22 +8,28 @@ RUN apt update \
     && rm -rf /var/lib/apt/lists/*
 
 # Clone repo
-ARG RICHIE_REPOSITORY=https://github.com/openfun/richie.git
-ARG RICHIE_VERSION={{ RICHIE_RELEASE_VERSION }}
-RUN git clone $RICHIE_REPOSITORY --branch $RICHIE_VERSION --depth 1 /richie
+ARG RICHIE_FACTORY_REPOSITORY={{ RICHIE_FACTORY_REPOSITORY }}
+ARG RICHIE_FACTORY_VERSION={{ RICHIE_FACTORY_VERSION }}
+ARG SITE
+RUN git clone $RICHIE_FACTORY_REPOSITORY --branch $RICHIE_FACTORY_VERSION --depth 1 /richie
 
 #--------- Front-end builder image
 FROM node:16 as frontend-builder
 
-COPY --from=base /richie/src/frontend /app/richie/src/frontend
-WORKDIR /app/richie/src/frontend
-RUN yarn install --frozen-lockfile && \
+ARG SITE
+
+COPY --from=base /richie/sites/${SITE}/src/frontend /app/richie/sites/${SITE}/src/frontend
+WORKDIR /app/richie/sites/${SITE}/src/frontend
+# --frozen-lockfile
+RUN yarn install && \
     yarn compile-translations && \
     yarn build-ts-production && \
     yarn build-sass-production
 
 #--------- Production image
 FROM python:3.7-bullseye as production
+
+ARG SITE
 
 RUN apt update \
     && apt install -y gettext git default-mysql-client \
@@ -33,13 +41,13 @@ RUN mkdir -p /data/media /data/static && chown -R openedx:openedx /data
 USER openedx
 
 COPY --from=base --chown=openedx:openedx /richie /app/richie
-WORKDIR /app/richie
+WORKDIR /app/richie/sites/${SITE}
 
 # Install project (with requirements)
 RUN python -m venv /app/venv
 ENV PATH /app/venv/bin:${PATH}
 RUN pip install pip==22.0.4 setuptools==62.1.0 wheel==0.37.1
-RUN pip install -e .[sandbox]
+RUN pip install -r requirements/base.txt
 RUN pip install uwsgi==2.0.20
 RUN pip install mysqlclient==2.1.0
 # The django-cms fork includes drillable search feature,
@@ -49,24 +57,27 @@ RUN pip install git+https://github.com/jbpenrath/django-cms@fun-3.11.0#egg=djang
 # Install requirements for storing media assets on S3/MinIO
 RUN pip install django-storages==1.12.3 boto3==1.20.25
 
-ENV DJANGO_SETTINGS_MODULE settings
+WORKDIR /app/richie/sites/${SITE}/src/backend
+
+ENV PYTHONPATH "${PYTHONPATH}:/app/richie/sites/${SITE}/src/backend"
+ENV DJANGO_SETTINGS_MODULE ${SITE}.settings
 ENV DJANGO_CONFIGURATION Production
 ENV DJANGO_SECRET_KEY setme
+ENV DJANGO_AWS_ACCESS_KEY_ID setme
+ENV DJANGO_AWS_SECRET_ACCESS_KEY setme
+
+ENV SITE=${SITE}
 
 # Collect static assets
 COPY --from=frontend-builder --chown=openedx:openedx \
-  /app/richie/src/richie/static/richie/js \
-  /app/richie/src/richie/static/richie/js
-COPY --from=frontend-builder --chown=openedx:openedx \
-  /app/richie/src/richie/static/richie/css/main.css \
-  /app/richie/src/richie/static/richie/css/main.css
-RUN ./sandbox/manage.py collectstatic
+    /app/richie/sites/${SITE}/src/backend/base/static/richie \
+    /app/richie/sites/${SITE}/src/backend/base/static/richie
+RUN ./manage.py collectstatic
 
 # Compile translations
-RUN ./sandbox/manage.py compilemessages
+RUN mkdir -p locale && ./manage.py compilemessages
 
 # Run server
-WORKDIR /app/richie/sandbox
 EXPOSE 8000
 CMD uwsgi \
     --static-map /static=/data/static/ \
@@ -77,4 +88,4 @@ CMD uwsgi \
     --enable-threads \
     --processes=${UWSGI_WORKERS:-2} \
     --buffer-size=8192 \
-    --wsgi-file wsgi.py
+    --wsgi-file ${SITE}/wsgi.py

--- a/tutorrichie/templates/richie/build/richie/Dockerfile
+++ b/tutorrichie/templates/richie/build/richie/Dockerfile
@@ -11,7 +11,7 @@ ARG RICHIE_VERSION={{ RICHIE_RELEASE_VERSION }}
 RUN git clone $RICHIE_REPOSITORY --branch $RICHIE_VERSION --depth 1 /richie
 
 #--------- Front-end builder image
-FROM node:14 as frontend-builder
+FROM node:16 as frontend-builder
 
 COPY --from=base /richie/src/frontend /app/richie/src/frontend
 WORKDIR /app/richie/src/frontend
@@ -42,10 +42,10 @@ RUN pip install pip==22.0.4 setuptools==62.1.0 wheel==0.37.1
 RUN pip install -e .[sandbox]
 RUN pip install uwsgi==2.0.20
 RUN pip install mysqlclient==2.1.0
-# Use temporarily a forked version of djangocms-admin-style
-# Remove this when djangocms-admin-style 2.0.3 will be released\
-# See upstream Dockerfile https://github.com/openfun/richie/blob/master/Dockerfile
-RUN pip install git+https://github.com/jbpenrath/djangocms-admin-style@fun#egg=djangocms-admin-style
+# The django-cms fork includes drillable search feature,
+# it should be removed when this feature will be officially released
+# See upstream Dockerfile https://github.com/openfun/fun-richie-site-factory/blob/main/Dockerfile
+RUN pip install git+https://github.com/jbpenrath/django-cms@fun-3.11.0#egg=django-cms
 # Install requirements for storing media assets on S3/MinIO
 RUN pip install django-storages==1.12.3 boto3==1.20.25
 

--- a/tutorrichie/templates/richie/hooks/richie/init
+++ b/tutorrichie/templates/richie/hooks/richie/init
@@ -1,11 +1,12 @@
+# TODO Update for richie-factory
 # Fix media permissions
 chown -R openedx:openedx /data/media
 
 # Create tables
-./sandbox/manage.py migrate
+./manage.py migrate
 
 # Create ES indices
-./sandbox/manage.py bootstrap_elasticsearch
+./manage.py bootstrap_elasticsearch
 
 # Create required pages
-./sandbox/manage.py richie_init
+./manage.py richie_init


### PR DESCRIPTION
## Problem
Tutor users can deploy and use Richie using this plugin. However, it seems that the only way to deploy a customised instance of Richie is to use a fork of Richie.

From openfun documentation, the recommended path to customise an instance is to use a [Richie site factory](https://richie.education/docs/cookiecutter/#). This is not supported by this plugin.

[Thread](https://discuss.openedx.org/t/customise-richie-theme/8090)

## Suggested solution
This PR is my first attempt at providing support for a Richie site factory. 

My goal is to implement a solution that keeps the user experience simple. Ideally, users just need to provide a `RICHIE_FACTORY_REPOSITORY` and `RICHIE_FACTORY_SITE` to deploy their customise instance.