### PR TITLE
fix: richie-openedx-job not picking the settings

### DIFF
--- a/tutorrichie/patches/local-docker-compose-jobs-services
+++ b/tutorrichie/patches/local-docker-compose-jobs-services
@@ -12,7 +12,7 @@ richie-openedx-job:
     image: {{ DOCKER_IMAGE_OPENEDX }}
     environment:
       SERVICE_VARIANT: cms
-      SETTINGS: ${TUTOR_EDX_PLATFORM_SETTINGS:-tutor.production}
+      DJANGO_SETTINGS_MODULE: cms.envs.tutor.production
     volumes:
       - ../apps/openedx/settings/lms/:/openedx/edx-platform/lms/envs/tutor/:ro
       - ../apps/openedx/settings/cms/:/openedx/edx-platform/cms/envs/tutor/:ro


### PR DESCRIPTION
This fixes an error when running `tutor local init` in the context of running the jobs of richie.  It would through an error because it didn't catche the correct settings module `'Settings' object has no attribute 'RICHIE_COURSE_HOOK'`